### PR TITLE
`DESYSubmitter` fallback option for when `qsub` is not available (DESY cluster)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": true,
+    "python.formatting.provider": "black"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "editor.formatOnSave": true,
-    "python.formatting.provider": "black"
-}

--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -481,7 +481,7 @@ class DESYSubmitter(Submitter):
 
         self.make_cluster_submission_script()
 
-        if self.manual_submit is not None:
+        if not self.manual_submit:
             process = subprocess.Popen(submit_cmd, stdout=subprocess.PIPE, shell=True)
             msg = process.stdout.read().decode()
             logger.info(str(msg))

--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -331,6 +331,15 @@ class DESYSubmitter(Submitter):
         )
         self.remove_old_logs = self.cluster_kwargs.get("remove_old_logs", True)
 
+        self.manual_submit = self.cluster_kwargs.get("manual_submit", False)
+
+        if not self.manual_submit:
+            if shutil.which(DESYSubmitter.submit_cmd) is None:
+                logger.warning(
+                    f"Submit command {DESYSubmitter.submit_cmd} is not available on the current host. Forcing 'manual_submit' mode."
+                )
+                self.manual_submit = True
+
     @staticmethod
     def _qstat_output(qstat_command):
         """return the output of the qstat_command"""
@@ -472,14 +481,15 @@ class DESYSubmitter(Submitter):
 
         self.make_cluster_submission_script()
 
-        if shutil.which(DESYSubmitter.submit_cmd) is not None:
+        if self.manual_submit is not None:
             process = subprocess.Popen(submit_cmd, stdout=subprocess.PIPE, shell=True)
             msg = process.stdout.read().decode()
             logger.info(str(msg))
             self.job_id = int(str(msg).split("job-array")[1].split(".")[0])
         else:
-            logger.warning(
-                f"Submit command {DESYSubmitter.submit_cmd} not found. If you are not running on a submission host, consider submitting the job manually by running on an enabled terminal the following command: \n {submit_cmd}"
+            print(
+                "Running in 'manual_submit' mode. Login to a submission host and launch the following command:\n",
+                submit_cmd,
             )
 
     # @staticmethod

--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -334,6 +334,8 @@ class DESYSubmitter(Submitter):
         self.manual_submit = self.cluster_kwargs.get("manual_submit", False)
 
         if not self.manual_submit:
+            print(shutil.which("qsub"))
+            print(shutil.which(DESYSubmitter.submit_cmd))
             if shutil.which(DESYSubmitter.submit_cmd) is None:
                 logger.warning(
                     f"Submit command {DESYSubmitter.submit_cmd} is not available on the current host. Forcing 'manual_submit' mode."

--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -467,16 +467,22 @@ class DESYSubmitter(Submitter):
         submit_cmd += (
             f"-t 1-{n_tasks}:1 {DESYSubmitter.submit_file} {path} {self.cluster_cpu}"
         )
-        logger.debug(f"Ram per core: {self.ram_per_core}")
+        logger.info(f"Ram per core: {self.ram_per_core}")
         logger.info(f"{time.asctime(time.localtime())}: {submit_cmd}")
 
         self.make_cluster_submission_script()
 
-        process = subprocess.Popen(submit_cmd, stdout=subprocess.PIPE, shell=True)
-        msg = process.stdout.read().decode()
-        logger.info(str(msg))
-        self.job_id = int(str(msg).split("job-array")[1].split(".")[0])
-
+        if shutil.which(DESYSubmitter.submit_cmd) is not None:
+            process = subprocess.Popen(submit_cmd, stdout=subprocess.PIPE, shell=True)
+            msg = process.stdout.read().decode()
+            logger.info(str(msg))
+            self.job_id = int(str(msg).split("job-array")[1].split(".")[0])
+        else:
+            logger.warning(
+                f"Submit command {DESYSubmitter.submit_cmd} not found. If you are not running on a submission host, consider submitting the job manually by running on an enabled terminal \n:
+                {submit_cmd}"
+            )
+            
     # @staticmethod
     # def _wait_for_cluster(job_ids=None):
     #     """Waits until the cluster is done. Wait for all jobs if job_ids is None or give a list of IDs"""

--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -487,9 +487,11 @@ class DESYSubmitter(Submitter):
             logger.info(str(msg))
             self.job_id = int(str(msg).split("job-array")[1].split(".")[0])
         else:
-            print(
-                "Running in 'manual_submit' mode. Login to a submission host and launch the following command:\n",
-                submit_cmd,
+            input(
+                f"Running in 'manual_submit' mode. Login to a submission host and launch the following command:\n"
+                f"{submit_cmd}\n"
+                f"Press enter to continue after the jobs are finished.\n"
+                f"[ENTER]"
             )
 
     # @staticmethod

--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -299,7 +299,7 @@ class DESYSubmitter(Submitter):
     submit_file = os.path.join(cluster_dir, "SubmitDESY.sh")
     username = os.path.basename(os.environ["HOME"])
     status_cmd = f"qstat -u {username}"
-    submit_cmd = "qsub "
+    submit_cmd = "qsub"
     root_dir = os.path.dirname(fs_dir[:-1])
 
     def __init__(self, mh_dict, use_cluster, n_cpu=None, **cluster_kwargs):
@@ -334,8 +334,6 @@ class DESYSubmitter(Submitter):
         self.manual_submit = self.cluster_kwargs.get("manual_submit", False)
 
         if not self.manual_submit:
-            print(shutil.which("qsub"))
-            print(shutil.which(DESYSubmitter.submit_cmd))
             if shutil.which(DESYSubmitter.submit_cmd) is None:
                 logger.warning(
                     f"Submit command {DESYSubmitter.submit_cmd} is not available on the current host. Forcing 'manual_submit' mode."
@@ -474,9 +472,9 @@ class DESYSubmitter(Submitter):
         # assemble the submit command
         submit_cmd = DESYSubmitter.submit_cmd
         if self.cluster_cpu > 1:
-            submit_cmd += " -pe multicore {0} -R y ".format(self.cluster_cpu)
+            submit_cmd += " -pe multicore {0} -R y".format(self.cluster_cpu)
         submit_cmd += (
-            f"-t 1-{n_tasks}:1 {DESYSubmitter.submit_file} {path} {self.cluster_cpu}"
+            f" -t 1-{n_tasks}:1 {DESYSubmitter.submit_file} {path} {self.cluster_cpu}"
         )
         logger.info(f"Ram per core: {self.ram_per_core}")
         logger.info(f"{time.asctime(time.localtime())}: {submit_cmd}")

--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -479,10 +479,9 @@ class DESYSubmitter(Submitter):
             self.job_id = int(str(msg).split("job-array")[1].split(".")[0])
         else:
             logger.warning(
-                f"Submit command {DESYSubmitter.submit_cmd} not found. If you are not running on a submission host, consider submitting the job manually by running on an enabled terminal \n:
-                {submit_cmd}"
+                f"Submit command {DESYSubmitter.submit_cmd} not found. If you are not running on a submission host, consider submitting the job manually by running on an enabled terminal the following command: \n {submit_cmd}"
             )
-            
+
     # @staticmethod
     # def _wait_for_cluster(job_ids=None):
     #     """Waits until the cluster is done. Wait for all jobs if job_ids is None or give a list of IDs"""


### PR DESCRIPTION
If `flarestack` is run on the DESY cluster but on a host which is not a [submission host](https://dv-zeuthen.desy.de/services/batch/overview/#e139869) (example: the [Zeuthen Jupyter server](jupyter.zeuthen.desy.de)), the submission will fail.

This (draft) PR introduces a check for `qsub` availability. When `qsub` is not available, the user is prompted with the possibility to manually submit the job by copy-pasting the command on an enable terminal.

So far I tested this only on the DESY JupyterHub. I will remove the _draft_ status as soon as I have tested that it works as intended on a submission node as well.