### PR TITLE
Cluster submission fixes

### DIFF
--- a/flarestack/cluster/make_desy_cluster_script.py
+++ b/flarestack/cluster/make_desy_cluster_script.py
@@ -2,6 +2,10 @@ import logging
 import os
 from flarestack.shared import fs_dir, log_dir, fs_scratch_dir
 
+"""
+WARNING: this module is deprecated. Check `flarestack.cluster.submitter` instead.
+"""
+
 logger = logging.getLogger(__name__)
 
 username = os.path.basename(os.environ["HOME"])

--- a/flarestack/cluster/make_desy_cluster_script.py
+++ b/flarestack/cluster/make_desy_cluster_script.py
@@ -2,11 +2,11 @@ import logging
 import os
 from flarestack.shared import fs_dir, log_dir, fs_scratch_dir
 
-"""
-WARNING: this module is deprecated. Check `flarestack.cluster.submitter` instead.
-"""
-
 logger = logging.getLogger(__name__)
+
+logger.warning(
+    "WARNING: this module is deprecated. Check `flarestack.cluster.submitter` instead."
+)
 
 username = os.path.basename(os.environ["HOME"])
 

--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -437,9 +437,7 @@ class DESYSubmitter(Submitter):
             "eval $(/cvmfs/icecube.opensciencegrid.org/py3-v4.1.0/setup.sh) \n"
             "export PYTHONPATH=" + DESYSubmitter.root_dir + "/ \n"
             "export FLARESTACK_SCRATCH_DIR=" + flarestack_scratch_dir + " \n"
-            f"{sys.executable} "
-            + fs_dir
-            + "core/multiprocess_wrapper.py -f $1 -n $2 \n"
+            f"{sys.executable} {fs_dir} core/multiprocess_wrapper.py -f $1 -n $2 \n"
             "cp $TMPDIR/${JOB_ID}_stdout.txt " + log_dir + "\n"
             "cp $TMPDIR/${JOB_ID}_stderr.txt " + log_dir + "\n "
         )

--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -1,4 +1,4 @@
-import os, subprocess, time, logging, shutil, copy
+import os, subprocess, time, logging, shutil, copy, sys
 import numpy as np
 from flarestack.shared import (
     fs_dir,
@@ -437,7 +437,9 @@ class DESYSubmitter(Submitter):
             "eval $(/cvmfs/icecube.opensciencegrid.org/py3-v4.1.0/setup.sh) \n"
             "export PYTHONPATH=" + DESYSubmitter.root_dir + "/ \n"
             "export FLARESTACK_SCRATCH_DIR=" + flarestack_scratch_dir + " \n"
-            "python " + fs_dir + "core/multiprocess_wrapper.py -f $1 -n $2 \n"
+            f"{sys.executable} "
+            + fs_dir
+            + "core/multiprocess_wrapper.py -f $1 -n $2 \n"
             "cp $TMPDIR/${JOB_ID}_stdout.txt " + log_dir + "\n"
             "cp $TMPDIR/${JOB_ID}_stderr.txt " + log_dir + "\n "
         )


### PR DESCRIPTION
Try to fix #181 following @robertdstein suggestion of using `sys.executable` as python command for running in the DESY cluster.

Adding a also deprecation warning to legacy `make_desy_cluster_script` module. 