### PR TITLE
Avoid override of input `mh_dict` when submitting to cluster

### DIFF
--- a/flarestack/cluster/submitter.py
+++ b/flarestack/cluster/submitter.py
@@ -464,6 +464,9 @@ class HTCondorSubmitter(Submitter):
     def submit_cluster(self, mh_dict):
         """Submits the job to the cluster"""
 
+        # copy the dictionary in order to avoid overriding the original
+        mh_dict = copy.deepcopy(mh_dict)
+
         if self.remove_old_logs:
             self.clear_log_dir()
 


### PR DESCRIPTION
Deepcopy the `mh_dict` in `Submitter.submit_cluster()` so when the correct `n_trials` for the tasks is assigned, the value in the original dictionary does not change. Should fix #353 