### PR TITLE
Remove registration of `standard_llh`

### DIFF
--- a/flarestack/core/llh.py
+++ b/flarestack/core/llh.py
@@ -702,7 +702,6 @@ class FixedEnergyLLH(LLH):
         return 2.0 * np.sum(llh_value)
 
 
-@LLH.register_subclass("standard")
 class StandardLLH(FixedEnergyLLH):
     fit_energy = True
 


### PR DESCRIPTION
`standard_llh` can not retrieve injected signal and should not be used. Removing the registration only makes it unusable in an analysis, but it can still be subclassed by working implementations. Related to #374 