### PR TITLE
Modify how spatial cache is created in StdMatrixKDEEnabledLLH

### DIFF
--- a/flarestack/core/llh.py
+++ b/flarestack/core/llh.py
@@ -1475,7 +1475,7 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
                     self.spatial_pdf.signal.SplineIs4D
                     and self.spatial_pdf.signal.KDE_eval_gamma is not None
                 ) or not self.spatial_pdf.signal.SplineIs4D:
-                    SoB_matrix_sparse[i, mask] = SoB_only_matrix[i, :].multiply(
+                    SoB_matrix_sparse[i, mask] = SoB_only_matrix[i, mask].multiply(
                         weight[i]
                     )
 

--- a/flarestack/core/llh.py
+++ b/flarestack/core/llh.py
@@ -1364,8 +1364,10 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
 
         if llh_dict["llh_spatial_pdf"]["spatial_pdf_name"] != "northern_tracks_kde":
             raise ValueError(
-                "Specified LLH ({}) is only compatible with NorthernTracksKDE, ".format(self.llh_dict["llh_name"]) +
-                "please change 'the spatial_pdf_name' accordingly"
+                "Specified LLH ({}) is only compatible with NorthernTracksKDE, ".format(
+                    self.llh_dict["llh_name"]
+                )
+                + "please change 'the spatial_pdf_name' accordingly"
             )
 
     def create_kwargs(self, data, pull_corrector, weight_f=None):
@@ -1401,13 +1403,19 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
                 # the spatial pdf is calculated (ie the KDE spline is evaluated) for gamma = 2
                 # If we want to be correct this should be in a loop for the get_gamma_support_points
                 # but that would add an extra dimension in the matrix so better not
-                if (self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is not None) or not self.spatial_pdf.signal.SplineIs4D:
+                if (
+                    self.spatial_pdf.signal.SplineIs4D
+                    and self.spatial_pdf.signal.KDE_eval_gamma is not None
+                ) or not self.spatial_pdf.signal.SplineIs4D:
 
                     sig = self.signal_pdf(source, coincident_data)  # gamma = None
 
-                elif self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is None:
+                elif (
+                    self.spatial_pdf.signal.SplineIs4D
+                    and self.spatial_pdf.signal.KDE_eval_gamma is None
+                ):
 
-                    sig = self.signal_pdf(source, coincident_data, gamma=2.)
+                    sig = self.signal_pdf(source, coincident_data, gamma=2.0)
 
                 nonzero_mask = sig > spatial_mask_threshold
                 s_mask[s_mask] *= nonzero_mask
@@ -1436,17 +1444,23 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
 
         # create sparse matrix with non-weighted SoB
         # relevant when signal pdf is gamma-independent so that spline evaluation is done once
-        if (self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is not None) or not self.spatial_pdf.signal.SplineIs4D:
-            logger.debug("Creating gamma-independent SoB matrix for all srcs when 3D KDE or 4D w/ 'spatial_pdf_index'")
+        if (
+            self.spatial_pdf.signal.SplineIs4D
+            and self.spatial_pdf.signal.KDE_eval_gamma is not None
+        ) or not self.spatial_pdf.signal.SplineIs4D:
+            logger.debug(
+                "Creating gamma-independent SoB matrix for all srcs when 3D KDE or 4D w/ 'spatial_pdf_index'"
+            )
 
             SoB_only_matrix = sparse.lil_matrix(coincidence_matrix.shape, dtype=float)
 
             for i, src in enumerate(coincident_sources):
                 mask = (coincidence_matrix.getrow(i)).toarray()[0]
-                SoB_only_matrix[i, mask] = (
-                    self.signal_pdf(src, coincident_data[mask])   # gamma = None
-                    / self.background_pdf(src, coincident_data[mask])
-                    )
+                SoB_only_matrix[i, mask] = self.signal_pdf(
+                    src, coincident_data[mask]
+                ) / self.background_pdf(  # gamma = None
+                    src, coincident_data[mask]
+                )
 
         def joint_SoB(dataset, gamma):
             weight = np.array(season_weight(gamma))
@@ -1459,10 +1473,18 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
             for i, src in enumerate(coincident_sources):
                 mask = (coincidence_matrix.getrow(i)).toarray()[0]
 
-                if (self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is not None) or not self.spatial_pdf.signal.SplineIs4D:
-                    SoB_matrix_sparse[i, mask] = SoB_only_matrix[i, :].multiply(weight[i])
+                if (
+                    self.spatial_pdf.signal.SplineIs4D
+                    and self.spatial_pdf.signal.KDE_eval_gamma is not None
+                ) or not self.spatial_pdf.signal.SplineIs4D:
+                    SoB_matrix_sparse[i, mask] = SoB_only_matrix[i, :].multiply(
+                        weight[i]
+                    )
 
-                elif self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is None:
+                elif (
+                    self.spatial_pdf.signal.SplineIs4D
+                    and self.spatial_pdf.signal.KDE_eval_gamma is None
+                ):
                     SoB_matrix_sparse[i, mask] = (
                         weight[i]
                         * self.signal_pdf(src, dataset[mask], gamma)

--- a/flarestack/core/llh.py
+++ b/flarestack/core/llh.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 import scipy.interpolate
 from scipy import sparse
+from typing import Optional
 import pickle
 from flarestack.shared import (
     acceptance_path,
@@ -1351,7 +1352,11 @@ class StandardMatrixLLH(StandardOverlappingLLH):
 @LLH.register_subclass("std_matrix_kde_enabled")
 class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
     """Similar to StandardMatrixLLH, but passing gamma to the spatial_pdf,
-    so the gamma-dependent KDE-implementation of the PSF can be used
+    so the gamma-dependent KDE-implementation of the PSF can be used.
+    The gamma-dependence is optional, only for 4D KDE when gamma not provided in the spatial_pdf_dict,
+    any other case is gamma-independent. In gamma-independent case, in order to optimize runtime
+    the spatial cache is created by evaluating the KDE spline once
+    and then weighting it for all gamma-grid points.
     """
 
     def create_kwargs(self, data, pull_corrector, weight_f=None):
@@ -1383,7 +1388,18 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
                 # things up (those neutrinos won't contribute anything to the
                 # likelihood!)
 
-                sig = self.signal_pdf(source, coincident_data)
+                # Note: in the case of 4D KDE & gamma not provided,
+                # the spatial pdf is calculated (ie the KDE spline is evaluated) for gamma = 2
+                # If we want to be correct this should be in a loop for the get_gamma_support_points
+                # but that would add an extra dimension in the matrix so better not
+                if (self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is not None) or not self.spatial_pdf.signal.SplineIs4D:
+
+                    sig = self.signal_pdf(source, coincident_data)  # gamma = None
+
+                elif self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is None:
+
+                    sig = self.signal_pdf(source, coincident_data, gamma=2.)
+
                 nonzero_mask = sig > spatial_mask_threshold
                 s_mask[s_mask] *= nonzero_mask
 
@@ -1409,6 +1425,20 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
 
         SoB_energy_cache = self.create_SoB_energy_cache(coincident_data)
 
+        # create sparse matrix with non-weighted SoB
+        # relevant when signal pdf is gamma-independent so that spline evaluation is done once
+        if (self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is not None) or not self.spatial_pdf.signal.SplineIs4D:
+            logger.debug("Creating gamma-independent SoB matrix for all srcs when 3D KDE or 4D w/ 'spatial_pdf_index'")
+
+            SoB_only_matrix = sparse.lil_matrix(coincidence_matrix.shape, dtype=float)
+
+            for i, src in enumerate(coincident_sources):
+                mask = (coincidence_matrix.getrow(i)).toarray()[0]
+                SoB_only_matrix[i, mask] = (
+                    self.signal_pdf(src, coincident_data[mask])   # gamma = None
+                    / self.background_pdf(src, coincident_data[mask])
+                    )
+
         def joint_SoB(dataset, gamma):
             weight = np.array(season_weight(gamma))
             weight /= np.sum(weight)
@@ -1419,11 +1449,16 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
 
             for i, src in enumerate(coincident_sources):
                 mask = (coincidence_matrix.getrow(i)).toarray()[0]
-                SoB_matrix_sparse[i, mask] = (
-                    weight[i]
-                    * self.signal_pdf(src, dataset[mask], gamma)
-                    / self.background_pdf(src, dataset[mask])
-                )
+
+                if (self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is not None) or not self.spatial_pdf.signal.SplineIs4D:
+                    SoB_matrix_sparse[i, mask] = SoB_only_matrix[i, :].multiply(weight[i])
+
+                elif self.spatial_pdf.signal.SplineIs4D and self.spatial_pdf.signal.KDE_eval_gamma is None:
+                    SoB_matrix_sparse[i, mask] = (
+                        weight[i]
+                        * self.signal_pdf(src, dataset[mask], gamma)
+                        / self.background_pdf(src, dataset[mask])
+                    )
 
             SoB_sum = SoB_matrix_sparse.sum(axis=0)
             return_value = np.array(SoB_sum).ravel()
@@ -1443,7 +1478,7 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
     # Signal PDF
     # ==========================================================================
 
-    def signal_pdf(self, source, cut_data, gamma=2.0):
+    def signal_pdf(self, source, cut_data, gamma: Optional[float] = None):
         """Calculates the value of the signal spatial PDF for a given source
         for each event in the coincident data subsample. If there is a Time PDF
         given, also calculates the value of the signal Time PDF for each event.

--- a/flarestack/core/llh.py
+++ b/flarestack/core/llh.py
@@ -1359,6 +1359,15 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
     and then weighting it for all gamma-grid points.
     """
 
+    def __init__(self, season, sources, llh_dict):
+        super().__init__(season, sources, llh_dict)
+
+        if llh_dict["llh_spatial_pdf"]["spatial_pdf_name"] != "northern_tracks_kde":
+            raise ValueError(
+                "Specified LLH ({}) is only compatible with NorthernTracksKDE, ".format(self.llh_dict["llh_name"]) +
+                "please change 'the spatial_pdf_name' accordingly"
+            )
+
     def create_kwargs(self, data, pull_corrector, weight_f=None):
         if weight_f is None:
             raise Exception(

--- a/flarestack/core/llh.py
+++ b/flarestack/core/llh.py
@@ -1407,14 +1407,12 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
                     self.spatial_pdf.signal.SplineIs4D
                     and self.spatial_pdf.signal.KDE_eval_gamma is not None
                 ) or not self.spatial_pdf.signal.SplineIs4D:
-
                     sig = self.signal_pdf(source, coincident_data)  # gamma = None
 
                 elif (
                     self.spatial_pdf.signal.SplineIs4D
                     and self.spatial_pdf.signal.KDE_eval_gamma is None
                 ):
-
                     sig = self.signal_pdf(source, coincident_data, gamma=2.0)
 
                 nonzero_mask = sig > spatial_mask_threshold

--- a/flarestack/core/results.py
+++ b/flarestack/core/results.py
@@ -40,7 +40,10 @@ class ResultsHandler(object):
 
         self.name = rh_dict["name"]
         self.mh_name = rh_dict["mh_name"]
-        self.scale = rh_dict["scale"]
+        if "fixed_scale" in list(rh_dict.keys()):
+            self.scale = rh_dict["fixed_scale"]
+        else:
+            self.scale = rh_dict["scale"]
 
         self.results = dict()
         self.pickle_output_dir = name_pickle_output_dir(self.name)

--- a/flarestack/core/spatial_pdf.py
+++ b/flarestack/core/spatial_pdf.py
@@ -235,11 +235,17 @@ class NorthernTracksKDE(SignalSpatialPDF):
         elif NorthernTracksKDE.KDEspline.ndim == 4:
             NorthernTracksKDE.SplineIs4D = True
             if "spatial_pdf_index" in spatial_pdf_dict.keys():
-                assert isinstance(spatial_pdf_dict["spatial_pdf_index"], float), "'spatial_pdf_index' is not float"
-                NorthernTracksKDE.KDE_eval_gamma = spatial_pdf_dict["spatial_pdf_index"] 
-                logger.debug(f"Fixing the gamma for 4D KDE spline evaluation to {NorthernTracksKDE.KDE_eval_gamma}") 
+                assert isinstance(
+                    spatial_pdf_dict["spatial_pdf_index"], float
+                ), "'spatial_pdf_index' is not float"
+                NorthernTracksKDE.KDE_eval_gamma = spatial_pdf_dict["spatial_pdf_index"]
+                logger.debug(
+                    f"Fixing the gamma for 4D KDE spline evaluation to {NorthernTracksKDE.KDE_eval_gamma}"
+                )
             else:
-                logger.warning("The 4D KDE spline will be evaluated each time for 144 gamma points, better be sure about this!")
+                logger.warning(
+                    "The 4D KDE spline will be evaluated each time for 144 gamma points, better be sure about this!"
+                )
         else:
             raise RuntimeError(
                 f"{KDEfile} does not seem to be a valid photospline table for the PSF"
@@ -256,7 +262,12 @@ class NorthernTracksKDE(SignalSpatialPDF):
                     d_psi
                     / (np.log(10) * psi_range)
                     * NorthernTracksKDE.KDEspline.evaluate_simple(
-                        [np.log10(sigma), logE, np.log10(psi_range), NorthernTracksKDE.KDE_eval_gamma]
+                        [
+                            np.log10(sigma),
+                            logE,
+                            np.log10(psi_range),
+                            NorthernTracksKDE.KDE_eval_gamma,
+                        ]
                     )
                 )
             else:
@@ -271,7 +282,9 @@ class NorthernTracksKDE(SignalSpatialPDF):
             psi_pdf = (
                 d_psi
                 / (np.log(10) * psi_range)
-                * NorthernTracksKDE.KDEspline.evaluate_simple([np.log10(sigma), logE, np.log10(psi_range)])
+                * NorthernTracksKDE.KDEspline.evaluate_simple(
+                    [np.log10(sigma), logE, np.log10(psi_range)]
+                )
             )
         psi_cdf = np.insert(psi_pdf.cumsum(), 0, 0)
         psi_range = np.insert(psi_range, 0, 0)
@@ -309,7 +322,7 @@ class NorthernTracksKDE(SignalSpatialPDF):
 
         :param source: Single Source
         :param cut_data: Subset of Dataset with coincident events
-        :param gamma (float | None): gamma = None if 3D KDE or 4D KDE with a specified gamma for spline evaluation, 
+        :param gamma (float | None): gamma = None if 3D KDE or 4D KDE with a specified gamma for spline evaluation,
                                 else gamma-dependent pdf
         :return: Array of Spatial PDF values
         """
@@ -322,7 +335,9 @@ class NorthernTracksKDE(SignalSpatialPDF):
 
         if NorthernTracksKDE.SplineIs4D:
             if NorthernTracksKDE.KDE_eval_gamma is not None:
-                assert gamma is None, "Provided gamma for 4D KDE spline evaluation, set gamma to None"
+                assert (
+                    gamma is None
+                ), "Provided gamma for 4D KDE spline evaluation, set gamma to None"
                 space_term = NorthernTracksKDE.KDEspline.evaluate_simple(
                     [
                         np.log10(cut_data["sigma"]),
@@ -332,7 +347,9 @@ class NorthernTracksKDE(SignalSpatialPDF):
                     ]
                 )
             else:
-                assert gamma is not None, "Chose 4D KDE and haven't provided gamma, you need gamma-dependence for evaluating spline"
+                assert (
+                    gamma is not None
+                ), "Chose 4D KDE and haven't provided gamma, you need gamma-dependence for evaluating spline"
                 space_term = NorthernTracksKDE.KDEspline.evaluate_simple(
                     [
                         np.log10(cut_data["sigma"]),
@@ -342,9 +359,13 @@ class NorthernTracksKDE(SignalSpatialPDF):
                     ]
                 )
         else:
-            assert gamma is None, "Using 3D KDE splines no need for gamma, set it to None"
+            assert (
+                gamma is None
+            ), "Using 3D KDE splines no need for gamma, set it to None"
             # paranoia
-            assert NorthernTracksKDE.KDE_eval_gamma is None, "Using 3D KDE splines no need to specify gamma"
+            assert (
+                NorthernTracksKDE.KDE_eval_gamma is None
+            ), "Using 3D KDE splines no need to specify gamma"
             space_term = NorthernTracksKDE.KDEspline.evaluate_simple(
                 [np.log10(cut_data["sigma"]), cut_data["logE"], np.log10(distance)]
             )

--- a/flarestack/core/spatial_pdf.py
+++ b/flarestack/core/spatial_pdf.py
@@ -218,7 +218,7 @@ class NorthernTracksKDE(SignalSpatialPDF):
     In the 3D case, there is no gamma-dependence for the spline evaluation by default.
     """
 
-    KDEspline = None
+    KDEspline = SplineTable
     KDE_eval_gamma = None
     SplineIs4D = False
 
@@ -253,7 +253,7 @@ class NorthernTracksKDE(SignalSpatialPDF):
 
         logger.info("Using KDE spatial PDF from file {0}.".format(KDEfile))
 
-    def _inverse_cdf(sigma, logE, gamma, npoints=100):
+    def _inverse_cdf(self, sigma, logE, gamma, npoints=100):
         psi_range = np.linspace(0.001, 0.5, npoints)
         d_psi = psi_range[1] - psi_range[0]
         if NorthernTracksKDE.SplineIs4D:
@@ -315,7 +315,7 @@ class NorthernTracksKDE(SignalSpatialPDF):
         return data.copy()
 
     @staticmethod
-    def signal_spatial(source, cut_data, gamma: Optional[float]):
+    def signal_spatial(source, cut_data, gamma: Optional[float]):  # type: ignore[override]
         """Calculates the angular distance between the source and the coincident dataset.
         This class provides an interface for the KDE-smoothed MC PDF introduced for the 10yr NT analysis.
         Returns the value of the PDF at the given distances between the source and the events.


### PR DESCRIPTION
**TL;DR**
Improve runtime for gamma-independent KDE cases used, by not evaluating the splines for all gamma points  when creating spatial cache

**Main changes**

- Introduce optional gamma-dependency in `signal_spatial` of `NorthernTracksKDE`
1. If 3D KDE, the spline is already created at given gamma, so no gamma-dependency when evaluating the spline => `signal_spatial` with gamma = None     
2. If 4D KDE, the spline evaluation is gamma-dependent. Added the option of specifying the gamma as "spatial_pdf_index" in `spatial_pdf_dict`, so this case is also gamma-independent and  `signal_spatial` is called with gamma = None. If gamma not specified by user, then `signal_spatial` is gamma-dependent

- Apply changes in `StdMatrixKDEEnabledLLH` 
1. `signal_pdf` method has now optional gamma-dependence,
2. this affects how coincident events are selected (mask for signal pdf above 1e-21)
3. in the gamma-independent cases, SoB-only sparse matrix is created outside `joint_SoB` so we avoid having the same spline evaluation for all the gamma support points.

**Miscellaneous**
Change the scale in `ResultsHandler` in order to avoid error when using "fixed_scale"

**Testing**
For some (unknown) reason, the full dataset passed in the llh is randomized even though the configuration is the same: no Poission injection, same seed, same catalog & dataset, 1 local trial for fixed scale. If dataset is saved and used for all testing trials then results are identical for main and branch 
