### PR TITLE
Appropriate configuration when applying pull correction

### DIFF
--- a/flarestack/core/angular_error_modifier.py
+++ b/flarestack/core/angular_error_modifier.py
@@ -375,7 +375,7 @@ class StaticMedianPullCorrector(BaseMedianAngularErrorModifier):
 
 class DynamicMedianPullCorrector(BaseMedianAngularErrorModifier):
     def __init__(self, pull_dict):
-        BaseAngularErrorModifier.__init__(self, pull_dict)
+        BaseMedianAngularErrorModifier.__init__(self, pull_dict)
 
     def estimate_spatial(self, gamma, spatial_cache):
         return self.estimate_spatial_dynamic(gamma, spatial_cache)

--- a/flarestack/core/angular_error_modifier.py
+++ b/flarestack/core/angular_error_modifier.py
@@ -406,7 +406,7 @@ class DynamicMedianPullCorrector(BaseMedianAngularErrorModifier):
             # have overlapping PDFs and you need to know the weights,
             # then you pass the key. Otherwise just evaluate as normal.
 
-            if len(inspect.getargspec(SoB_pdf)[0]) == 2:
+            if len(inspect.getfullargspec(SoB_pdf)[0]) == 2:
                 SoB = SoB_pdf(cut_data, key)
             else:
                 SoB = SoB_pdf(cut_data)

--- a/flarestack/core/angular_error_modifier.py
+++ b/flarestack/core/angular_error_modifier.py
@@ -341,7 +341,7 @@ class BaseMedianAngularErrorModifier(BaseAngularErrorModifier):
         else:
             logger.debug(f"Loading from {self.pull_name}")
 
-        with open(self.pull_name, "r") as f:
+        with open(self.pull_name, "rb") as f:
             self.pickled_data = Pickle.load(f)
 
     def pull_correct(self, f, data):

--- a/flarestack/core/minimisation.py
+++ b/flarestack/core/minimisation.py
@@ -325,18 +325,18 @@ class MinimisationHandler(object):
         return self._injectors[season_name]
 
     def add_angular_error_modifier(self, season):
-        dynamic_floors = ["quantile_floor_0d_e", "quantile_floor_1d_e"]
-        dynamic_pulls = ["median_0d_e", "median_1d_e", "median_2d_e"]
+        static_floors = ["quantile_floor_0d"]
+        static_pulls = ["median_1d", "median_2d"]
 
         # if static then both floor & pull need gamma in the e_pdf_dict for weighting MC
         if ("gamma" not in self.llh_dict["llh_energy_pdf"].keys()) and (
-            self.floor_name not in dynamic_floors
-            and self.pull_name not in dynamic_pulls
+            self.floor_name in static_floors and self.pull_name in static_pulls
         ):
             raise KeyError(
-                f"You chose static floor {self.floor_name} and/or static pull correction {self.pull_name} "
-                "without fixing the gamma. Please provide the gamma in the llh_energy_pdf dictionary, "
-                "or choose dynamic floor/pull if you want to fit the gamma."
+                "You chose static floor and/or static pull correction without fixing the gamma. "
+                "Please provide the gamma in the llh_energy_pdf dictionary "
+                f"if choosing from {static_floors} and/or {static_pulls}, "
+                "or choose dynamic floor/pull where gamma is fitted."
             )
 
         return BaseAngularErrorModifier.create(

--- a/flarestack/core/minimisation.py
+++ b/flarestack/core/minimisation.py
@@ -316,7 +316,7 @@ class MinimisationHandler(object):
     def add_angular_error_modifier(self, season):
         return BaseAngularErrorModifier.create(
             season,
-            self.llh_dict["llh_energy_pdf"],
+            self.inj_dict["injection_energy_pdf"],
             self.floor_name,
             self.pull_name,
             gamma_precision=self.llh_dict.get("gamma_precision", "flarestack"),

--- a/flarestack/core/minimisation.py
+++ b/flarestack/core/minimisation.py
@@ -190,6 +190,17 @@ class MinimisationHandler(object):
 
         try:
             self.pull_name = self.llh_dict["pull_name"]
+
+            if (
+                self.llh_dict["llh_name"]
+                in ["standard_kde_enabled", "std_matrix_kde_enabled"]
+                and self.pull_name != "no_pull"
+            ):
+                raise ValueError(
+                    "You are using a KDE-based llh but chose to have pull correction."
+                    "KDEs already account for that, please remove it from the llh_dict."
+                )
+
         except KeyError:
             self.pull_name = "no_pull"
 

--- a/flarestack/core/minimisation.py
+++ b/flarestack/core/minimisation.py
@@ -328,21 +328,20 @@ class MinimisationHandler(object):
         dynamic_floors = ["quantile_floor_0d_e", "quantile_floor_1d_e"]
         dynamic_pulls = ["median_0d_e", "median_1d_e", "median_2d_e"]
 
-        if self.floor_name in dynamic_floors and self.pull_name in dynamic_pulls:
-            aem_epdf_dict = self.llh_dict["llh_energy_pdf"]
-
         # if static then both floor & pull need gamma in the e_pdf_dict for weighting MC
-        # choose e_pdf from llh & gamma from inj dict
-        # TODO: When unblinding there is no inj dict passed in unblind dict,
-        # so either accommodate for static cases or exclude them altogether
-        else:
-            llh_epdf = self.llh_dict["llh_energy_pdf"]["energy_pdf_name"]
-            gamma = self.inj_dict["injection_energy_pdf"]["gamma"]
-            aem_epdf_dict = {"energy_pdf_name": llh_epdf, "gamma": gamma}
+        if ("gamma" not in self.llh_dict["llh_energy_pdf"].keys()) and (
+            self.floor_name not in dynamic_floors
+            and self.pull_name not in dynamic_pulls
+        ):
+            raise KeyError(
+                f"You chose static floor {self.floor_name} and/or static pull correction {self.pull_name} "
+                "without fixing the gamma. Please provide the gamma in the llh_energy_pdf dictionary, "
+                "or choose dynamic floor/pull if you want to fit the gamma."
+            )
 
         return BaseAngularErrorModifier.create(
             season,
-            aem_epdf_dict,
+            self.llh_dict["llh_energy_pdf"],
             self.floor_name,
             self.pull_name,
             gamma_precision=self.llh_dict.get("gamma_precision", "flarestack"),

--- a/flarestack/core/results.py
+++ b/flarestack/core/results.py
@@ -795,7 +795,7 @@ class ResultsHandler(object):
 
             xrange = np.linspace(0.0, 1.1 * max(x), 1000)
 
-            savepath = os.path.join(self.plot_dir, "disc" + ["", "_25"][i] + ".pdf")
+            savepath = os.path.join(self.plot_dir, "disc" + ["_25", ""][i] + ".pdf")
 
             fig = plt.figure()
             ax1 = fig.add_subplot(111)

--- a/flarestack/core/ts_distributions.py
+++ b/flarestack/core/ts_distributions.py
@@ -283,7 +283,7 @@ def plot_expanded_negative(ts_array, path):
 
 
 def plot_background_ts_distribution(
-    ts_array, path, ts_type="Standard", ts_val=None, mock_unblind=False
+    ts_array, path, ts_type="standard", ts_val=None, mock_unblind=False
 ):
     try:
         os.makedirs(os.path.dirname(path))

--- a/flarestack/utils/dynamic_pull_correction.py
+++ b/flarestack/utils/dynamic_pull_correction.py
@@ -10,7 +10,7 @@ from flarestack.utils.make_SoB_splines import get_gamma_support_points
 
 
 def get_mc(floor_dict):
-    return data_loader(floor_dict["season"]["mc_path"])
+    return data_loader(floor_dict["season"].mc_path)
 
 
 def get_pulls(mc):


### PR DESCRIPTION
### "Fix" to #363:
In case of `power_law` epdf, if you choose _static_ floors and pull correctors (eg `median_1d`) you need to provide the gamma in order to weight the MC, so basically these are applicable for fixed-gamma power law. Hence, raise an error if gamma is not provided in the `llh_energy_pdf` for these cases. 
 
### Other changes:  
- in minimizer, raise error if try applying pull correction when choosing KDEs (ie `llh_name` either `standard_kde_enabled` or `std_matrix_kde_enabled`) since KDEs already account for this
- in `ts_distributions`, compatibility of `ts_type` param between `plot_background_ts_distribution` and `fit_background_ts` methods
- in ResultsHandler `find_disc_potential`, correct plot names when discovery potential threshold from chi2 fit and TS=25