### PR TITLE
Use global rng in NTSeason.simulate_background

### DIFF
--- a/flarestack/data/icecube/northern_tracks/__init__.py
+++ b/flarestack/data/icecube/northern_tracks/__init__.py
@@ -64,7 +64,7 @@ class NTSeason(IceCubeSeason):
         return mc
 
     def simulate_background(self):
-        rng = np.random.default_rng()
+        rng = np.random
 
         if self.loaded_background_model is None:
             raise RuntimeError(


### PR DESCRIPTION
`NTSeason.simulate_background()` instantiates a fresh RNG each time it is called, using entropy from the system, whereas most (all?) of the rest of flarestack uses the global RNG `numpy.random`. Use the global RNG instead, so that `MinimizationHandler.prepare_dataset()` setting of the global seed has the intended effect.