### PR TITLE
More large-catalog speedups

### DIFF
--- a/flarestack/core/injector.py
+++ b/flarestack/core/injector.py
@@ -128,7 +128,7 @@ class BaseInjector:
         else:
             name = source["source_name"]
 
-        return np.copy(self.n_exp[self.n_exp["source_name"] == name])
+        return self.n_exp[self.n_exp["source_name"] == name]
 
     def get_expectation(self, source, scale):
         return float(self.get_n_exp_single(source)["n_exp"]) * scale
@@ -260,7 +260,7 @@ class MCInjector(BaseInjector):
 
         band_mask = self.get_band_mask(source, min_dec, max_dec)
 
-        return np.copy(self._mc[band_mask]), omega, band_mask
+        return self._mc[band_mask], omega, band_mask
 
     def get_band_mask(self, source, min_dec, max_dec):
         # Checks if the mask has already been evaluated for the source

--- a/flarestack/core/injector.py
+++ b/flarestack/core/injector.py
@@ -4,6 +4,7 @@ import numpy as np
 import random
 import zipfile
 import zlib
+from astropy.table import Table
 from flarestack.shared import band_mask_cache_name
 from flarestack.core.energy_pdf import EnergyPDF, read_e_pdf_dict
 from flarestack.core.time_pdf import TimePDF, read_t_pdf_dict
@@ -228,7 +229,7 @@ class MCInjector(BaseInjector):
 
     def __init__(self, season, sources, **kwargs):
         kwargs = read_injector_dict(kwargs)
-        self._mc = season.get_mc()
+        self._mc = self.get_mc(season)
         BaseInjector.__init__(self, season, sources, **kwargs)
 
         self.injection_declination_bandwidth = self.inj_kwargs.pop(
@@ -242,6 +243,9 @@ class MCInjector(BaseInjector):
         except KeyError:
             logger.warning("No Injection Arguments. Are you unblinding?")
             pass
+
+    def get_mc(self, season):
+        return season.get_mc()
 
     def select_mc_band(self, source):
         """For a given source, selects MC events within a declination band of
@@ -520,6 +524,34 @@ class LowMemoryInjector(MCInjector):
         # band_mask = self.load_band_mask(mask_index[0])
 
         return self.band_mask_cache.getrow(entry["source_index"][0]).toarray()[0]
+
+
+@MCInjector.register_subclass("table_injector")
+class TableInjector(MCInjector):
+    """
+    For even larger numbers of sources O(~1000), accessing every element of the
+    MC array in select_band_mask() once for every source in calculate_n_exp()
+    becomes a bottleneck. Store event fields in columns, ordered by declination,
+    making single-field accesses vastly cheaper and band masks practically free.
+    For 1000 sources, calculate_n_exp() is ~60x faster than MCInjector.
+    """
+
+    def get_mc(self, season):
+        mc: np.ndarray = season.get_mc()
+        # Sort rows by trueDec, and store as columns in a Table
+        table = Table(mc[np.argsort(mc["trueDec"].copy())])
+        # Prevent in-place modifications
+        for k in table.columns:
+            table[k].setflags(write=False)
+        return table
+
+    def get_band_mask(self, source, min_dec, max_dec):
+        return slice(*np.searchsorted(self._mc["trueDec"], [min_dec, max_dec]))
+
+    def select_mc_band(self, source):
+        table, omega, band_mask = super().select_mc_band(source)
+        # allow individual columns to be replaced
+        return table.copy(copy_data=False), omega, band_mask
 
 
 @MCInjector.register_subclass("effective_area_injector")

--- a/flarestack/core/llh.py
+++ b/flarestack/core/llh.py
@@ -1407,21 +1407,24 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
                 "standard_overlapping LLH functions."
             )
 
+        # Keep data in an astropy Table (column-wise) to improve cache
+        # performance. Sort to allow get_spatially_coincident_indices to find
+        # declination bands by binary search.
         data = Table(data[np.argsort(data[["dec", "ra"]])])
 
-        coincidence_matrix_rows = []
+        SoB_rows = [None] * len(self.sources)
 
         kwargs = dict()
 
         kwargs["n_all"] = float(len(data))
 
-        sources = self.sources
-
-        for i, source in enumerate(sources):
+        # Treat sources in declination order to keep caches hot
+        order = np.argsort(self.sources[["dec_rad", "ra_rad"]])
+        for i in order:
+            source = self.sources[i]
             idx = self.get_spatially_coincident_indices(data, source)
-            coincident_data = data[idx]
 
-            if len(coincident_data) > 0:
+            if len(idx) > 0:
                 # Only bother accepting neutrinos where the spacial
                 # likelihood is greater than 1e-21. This prevents 0s
                 # appearing in dynamic pull corrections, but also speeds
@@ -1432,6 +1435,7 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
                 # the spatial pdf is calculated (ie the KDE spline is evaluated) for gamma = 2
                 # If we want to be correct this should be in a loop for the get_gamma_support_points
                 # but that would add an extra dimension in the matrix so better not
+                coincident_data = data[idx]
                 if (
                     self.spatial_pdf.signal.SplineIs4D
                     and self.spatial_pdf.signal.KDE_eval_gamma is not None
@@ -1444,34 +1448,35 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
                 ):
                     sig = self.signal_pdf(source, coincident_data, gamma=2.0)
 
-                nonzero_idx = np.nonzero(sig > spatial_mask_threshold)[0]
+                nonzero_idx = np.nonzero(sig > spatial_mask_threshold)
                 column_indices = idx[nonzero_idx]
 
-                coincidence_matrix_rows.append(
-                    sparse.csr_matrix(
-                        (
-                            np.ones(column_indices.shape, dtype=bool),
-                            column_indices,
-                            [0, len(column_indices)],
-                        ),
-                        shape=(1, len(data)),
-                    )
+                # build a single-row CSR matrix in canonical format
+                SoB_rows[i] = sparse.csr_matrix(
+                    (
+                        sig[nonzero_idx]
+                        / self.background_pdf(source, coincident_data[nonzero_idx]),
+                        column_indices,
+                        [0, len(column_indices)],
+                    ),
+                    shape=(1, len(data)),
                 )
+            else:
+                SoB_rows[i] = sparse.csr_matrix((1, len(data)), dtype=float)
 
-        coincidence_matrix = sparse.vstack(coincidence_matrix_rows)
+        SoB_only_matrix = sparse.vstack(SoB_rows, format="csr")
 
-        # Using Sparse matrixes
-        coincident_nu_mask = np.sum(coincidence_matrix, axis=0) > 0
-        coincident_nu_mask = np.array(coincident_nu_mask).ravel()
-        coincident_source_mask = np.sum(coincidence_matrix, axis=1) > 0
-        coincident_source_mask = np.array(coincident_source_mask).ravel()
+        coincident_nu_mask = np.asarray(np.sum(SoB_only_matrix, axis=0) != 0).ravel()
+        coincident_source_mask = np.asarray(
+            np.sum(SoB_only_matrix, axis=1) != 0
+        ).ravel()
 
-        coincidence_matrix = (
-            coincidence_matrix[coincident_source_mask].T[coincident_nu_mask].T
+        SoB_only_matrix = (
+            SoB_only_matrix[coincident_source_mask].T[coincident_nu_mask].T
         )
 
         coincident_data = data[coincident_nu_mask]
-        coincident_sources = sources[coincident_source_mask]
+        coincident_sources = self.sources[coincident_source_mask]
 
         season_weight = lambda x: weight_f([1.0, x], self.season)[
             coincident_source_mask
@@ -1489,18 +1494,6 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
                 "Creating gamma-independent SoB matrix for all srcs when 3D KDE or 4D w/ 'spatial_pdf_index'"
             )
 
-            SoB_only_matrix = sparse.lil_matrix(coincidence_matrix.shape, dtype=float)
-
-            for i, src in enumerate(coincident_sources):
-                mask = (coincidence_matrix.getrow(i)).toarray()[0]
-                SoB_only_matrix[i, mask] = self.signal_pdf(
-                    src, coincident_data[mask]
-                ) / self.background_pdf(  # gamma = None
-                    src, coincident_data[mask]
-                )
-
-            SoB_only_matrix = SoB_only_matrix.tocsr()
-
             def joint_SoB(dataset, gamma):
                 weight = np.array(season_weight(gamma))
                 weight /= np.sum(weight)
@@ -1516,19 +1509,25 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
                 weight = np.array(season_weight(gamma))
                 weight /= np.sum(weight)
 
-                # create an empty lil_matrix (good for matrix creation) with shape
-                # of coincidence_matrix and type float
-                SoB_matrix_sparse = sparse.lil_matrix(
-                    coincidence_matrix.shape, dtype=float
-                )
-
+                # Build CSR matrix containing source_weight * S / B, with the
+                # same sparsity structure as SoB_only_matrix, taking advantage
+                # of the fact that the column indices are indices into `dataset`
+                data = np.empty_like(SoB_only_matrix.data)
                 for i, src in enumerate(coincident_sources):
-                    mask = (coincidence_matrix.getrow(i)).toarray()[0]
-                    SoB_matrix_sparse[i, mask] = (
-                        weight[i]
-                        * self.signal_pdf(src, dataset[mask], gamma)
-                        / self.background_pdf(src, dataset[mask])
+                    row = slice(
+                        SoB_only_matrix.indptr[i], SoB_only_matrix.indptr[i + 1]
                     )
+                    masked_dataset = dataset[SoB_only_matrix.indices[row]]
+                    data[row] = (
+                        weight[i]
+                        * self.signal_pdf(src, masked_dataset, gamma)
+                        / self.background_pdf(src, masked_dataset)
+                    )
+
+                SoB_matrix_sparse = sparse.csr_matrix(
+                    (data, SoB_only_matrix.indices, SoB_only_matrix.indptr),
+                    shape=SoB_only_matrix,
+                )
 
                 SoB_sum = SoB_matrix_sparse.sum(axis=0)
                 return_value = np.array(SoB_sum).ravel()

--- a/flarestack/core/minimisation.py
+++ b/flarestack/core/minimisation.py
@@ -1267,7 +1267,7 @@ class LargeCatalogueMinimisationHandler(FixedWeightMinimisationHandler):
 
     compatible_llh = ["standard_matrix", "std_matrix_kde_enabled"]
     compatible_negative_n_s = False
-    compatible_injectors = ["low_memory_injector"]
+    compatible_injectors = ["low_memory_injector", "table_injector"]
 
     def __init__(self, mh_dict):
         FixedWeightMinimisationHandler.__init__(self, mh_dict)

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,13 +2,7 @@
 packages = flarestack
 exclude = analyses
 
-[mypy-astropy]
-ignore_missing_imports = True
-
-[mypy-astropy.coordinates]
-ignore_missing_imports = True
-
-[mypy-astropy.cosmology]
+[mypy-astropy.*]
 ignore_missing_imports = True
 
 [mypy-healpy]


### PR DESCRIPTION
This PR introduces a bundle of changes, that, together with #396, reduce the time to initialize an injector and run a single trial with 10k sources and the 10-year NT dataset (gamma_precision reduced to 0.25, so only 8 gamma points) from 6.2 hours to 3 minutes. Of that, a solid 2 minutes are spent in `load_data()`*. The speedups arise as follows:

- Add a new TableInjector that keeps its MC data in an `astropy.table.Table`, sorted by declination, rather than in a gigantic structured array. This helps in two ways. First, operations on individual columns of the table make better use of caches, since the values are stored contiguously in memory, rather than 176 bytes apart as in the array. Second, sorting the table by declination means that the expensive band-masking step can be replaced by a cheap binary search. This is also more cache-efficient than indexing with a boolean array, since applying a boolean mask requires reading every single value in the column (or worse, the structured array). This injector is in all ways better than LowMemoryInjector (and perhaps, the base MCInjector)
- Optimize StdMatrixKDEEnabledLLH's coincident event selection in much the same way, using a Table to store the input data, sorted in declination, and processing sources in declination order.
- Build up SoB_only_matrix row-by-row in canonical CSR format, and skip constructing an explicit coincidence matrix entirely. Updating a scipy.sparse matrix turns out to be surprisingly expensive, and largely unnecessary.

*Most of the remaining fat is in flarestack.icecube_utils.dataset_loader.load_dataset() and its use of append_records(). This could be obviated by using astropy Table everywhere, but would make the most sense if the data were stored that way in the first place. That's probably too large of a change at this point.