### PR TITLE
Minor bug fixes

### DIFF
--- a/flarestack/core/injector.py
+++ b/flarestack/core/injector.py
@@ -714,6 +714,7 @@ class MockUnblindedInjector:
     def __init__(self, season, sources=np.nan, **kwargs):
         self.season = season
         self._raw_data = season.get_exp_data()
+        season.load_background_model()
 
     def create_dataset(self, scale, angular_error_modifier=None):
         """Returns a background scramble

--- a/flarestack/core/llh.py
+++ b/flarestack/core/llh.py
@@ -1526,7 +1526,7 @@ class StdMatrixKDEEnabledLLH(StandardOverlappingLLH):
 
                 SoB_matrix_sparse = sparse.csr_matrix(
                     (data, SoB_only_matrix.indices, SoB_only_matrix.indptr),
-                    shape=SoB_only_matrix,
+                    shape=SoB_only_matrix.shape,
                 )
 
                 SoB_sum = SoB_matrix_sparse.sum(axis=0)

--- a/flarestack/core/minimisation.py
+++ b/flarestack/core/minimisation.py
@@ -330,7 +330,7 @@ class MinimisationHandler(object):
 
         # if static then both floor & pull need gamma in the e_pdf_dict for weighting MC
         if ("gamma" not in self.llh_dict["llh_energy_pdf"].keys()) and (
-            self.floor_name in static_floors and self.pull_name in static_pulls
+            self.floor_name in static_floors or self.pull_name in static_pulls
         ):
             raise KeyError(
                 "You chose static floor and/or static pull correction without fixing the gamma. "


### PR DESCRIPTION
1. Avoid RuntimeError when calling `season.simulate_background()` in MockUnblindedInjector by adding `season.load_background_model()` at initialization.
2. In StdMatrixKDEEnabledLLH when creating the kwargs for the 4D KDE w/o specifying the gamma case. In the `joint_SoB` method when making the `SoB_matrix_sparse`, set the shape to `SoB_only_matrix.shape` instead of the matrix itself.
3. In MinimisationHandler `add_angular_error_modifier` method, change the if statement for the static floor & pull case: both necessitate gamma-dependent e_pdf_dict, so replace `and` to `or` in order to catch either of the cases. 