### PR TITLE
Run trials for fixed gamma

### DIFF
--- a/flarestack/core/minimisation.py
+++ b/flarestack/core/minimisation.py
@@ -570,7 +570,6 @@ class FixedWeightMinimisationHandler(MinimisationHandler):
     def run_trial_fixed_gamma(self, full_dataset):
         """Same as run_trial method but change
         the llh func to fix gamma param in the minimizer.
-        Disclaimer: Brute force minimization NOT implemented!!!!
         """
 
         raw_f = self.trial_function(full_dataset)
@@ -584,12 +583,12 @@ class FixedWeightMinimisationHandler(MinimisationHandler):
 
             start_seed = scipy.optimize.brute(
                 llh_f, ranges=brute_range, args=(self.llh_gamma,), finish=None, Ns=40
-            )[0]
+            )
         else:
             start_seed = np.array(self.p0[:-1])
 
         res = scipy.optimize.minimize(
-            llh_f, start_seed, args=(self.llh_gamma,), bounds=[self.bounds[:-1]]
+            llh_f, start_seed, args=(self.llh_gamma,), bounds=self.bounds[:-1]
         )
         best_ns = res.x
         vals = [best_ns, self.llh_gamma]
@@ -622,7 +621,7 @@ class FixedWeightMinimisationHandler(MinimisationHandler):
                 # for less than 40 parameters try with brute force grid evaluation
                 best_ns = scipy.optimize.brute(
                     llh_f, ranges=self.bounds[:-1], args=(self.llh_gamma,), finish=None
-                )[0]
+                )
                 vals = [best_ns, self.llh_gamma]
 
         best_llh = raw_f(vals)

--- a/flarestack/core/minimisation.py
+++ b/flarestack/core/minimisation.py
@@ -502,7 +502,6 @@ class FixedWeightMinimisationHandler(MinimisationHandler):
             start_seed = self.p0
 
         res = scipy.optimize.minimize(llh_f, start_seed, bounds=self.bounds)
-        vals = res.x
 
         flag = res.status
         # If the minimiser does not converge, try different strategy
@@ -530,6 +529,9 @@ class FixedWeightMinimisationHandler(MinimisationHandler):
             else:
                 # for less than 40 parameters try with brute force grid evaluation
                 vals = scipy.optimize.brute(llh_f, ranges=self.bounds, finish=None)
+
+        else:
+            vals = res.x
 
         best_llh = raw_f(vals)
 


### PR DESCRIPTION
Change the minimizer to accommodate for trials where gamma is fixed and only n_s is fitted.
To do so, set "fix_gamma" key to True in the `mh_dict` and have the same gamma in the llh and injection energy pdfs.
Introduce `run_trial_fixed_gamma()`: 
1. changed args passed in the function to minimize (ie `llh_f(ns, gamma)`). 
2. gamma param is then fixed to the llh gamma at the minimize method, while seed and bounds correspond only to ns 
3. fixed gamma trials can be run for `FitWeightMinimisationHandler` (in principle)

Validation: 1000 injection and 10000 background trials for point source analysis with KDE spatial pdf
<img width="300" height="600" alt="test_fixed_gamma_trials_full_cat_N1_bias_gamma" src="https://github.com/user-attachments/assets/57fa1340-c1c1-4c63-86b3-14f084c01f94" /> <img width="300" height="600" alt="test_fixed_gamma_trials_full_cat_N1_bias_ns" src="https://github.com/user-attachments/assets/e665952a-026e-449d-aa21-bd80f64af175" />  <img width="300" height="600" alt="test_fixed_gamma_trials_full_cat_N1_sensitivity" src="https://github.com/user-attachments/assets/448c17f9-4b0b-4799-ae5a-2dc50fcf86c4" />


### BUGFIX:
If the standard minimization failed but the attempt using differential evolution succeded, the vals of the original, failed attempt were used previously!
