### PR TITLE
Run CI against master branch

### DIFF
--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -7,10 +7,10 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/flarestack/core/results.py
+++ b/flarestack/core/results.py
@@ -719,6 +719,7 @@ class ResultsHandler(object):
 
             # this trick could be replaced by calling f on the vector of best fit parameters
             best_f = None
+            interpolated_flux = np.nan
 
             try:
                 res = scipy.optimize.curve_fit(
@@ -739,13 +740,10 @@ class ResultsHandler(object):
                 # estimate the solution flux
                 interpolated_flux = scipy.stats.gamma.ppf(0.5, best_a, best_b, best_c)
 
-                # "disc_potential" and "disc_potential_25" attributes are set here
-                # use of `setattr` makes the code a bit obscure and could be improved
-                discovery_flux[zval] = k_to_flux(interpolated_flux)
-
             except RuntimeError as e:
                 logger.warning(f"RuntimeError for discovery potential!: {e}")
-                # interpolated_flux = np.nan
+
+            discovery_flux[zval] = k_to_flux(interpolated_flux)
 
             # now plot the whole ordeal
             xrange = np.linspace(0.0, 1.1 * max(x), 1000)

--- a/flarestack/core/results.py
+++ b/flarestack/core/results.py
@@ -763,7 +763,7 @@ class ResultsHandler(object):
                 ax1.axvline(k_to_flux(interpolated_flux), lw=2, color="red")
             ax1.set_ylim(0.0, 1.0)
             ax1.set_xlim(0.0, k_to_flux(max(xrange)))
-            ax1.set_ylabel(r"Overfluctuations relative to f{zval}$\sigma$ threshold")
+            ax1.set_ylabel(rf"Overfluctuations relative to {zval}$\sigma$ threshold")
             plt.xlabel(r"Flux Normalisation @ 1GeV [ GeV$^{-1}$ cm$^{-2}$ s$^{-1}$]")
 
             if not np.isnan(self.flux_to_ns):


### PR DESCRIPTION
#443 set the CI job to run only on pushes and PRs to the main branch, but the default branch is still called master. As a result, CI never ran, and PR checks stayed in the "waiting for status to be reported" forever.

Along the way, fix a bug that wasn't caught in the mean time.