### PR TITLE
Shuffling NTSeason background events in RA and updates on sensitivity curve errorbars

### DIFF
--- a/flarestack/core/results.py
+++ b/flarestack/core/results.py
@@ -521,7 +521,7 @@ class ResultsHandler(object):
         either case, a plot of the overfluctuations as a function of the
         injected signal is produced.
         """
-        x_acc, y, yerr = [], [], []
+        x_acc, y, yerr, yerr_ts_jitter = [], [], [], []
         x = self.scale_labels
 
         for scale in x:
@@ -542,6 +542,12 @@ class ResultsHandler(object):
                 x_acc.append(float(scale))
                 yerr.append(1.0 / np.sqrt(float(len(ts_array))))
 
+                # another way to estimate the error on the overfluctuation fractions
+                ts_mean_fluc = np.mean(ts_array) / np.sqrt(len(ts_array))
+                frac_ul = float(len(ts_array[ts_array + ts_mean_fluc > ts_val])) / (float(len(ts_array)))
+                frac_ll = float(len(ts_array[ts_array - ts_mean_fluc > ts_val])) / (float(len(ts_array)))
+                yerr_ts_jitter.append(np.max([(frac_ul-frac_ll)/2., 1e-5]))
+
                 if frac != 0.0:
                     logger.info(f"Making plot for {scale=}, {frac=}")
                     self.make_plots(scale)
@@ -555,13 +561,13 @@ class ResultsHandler(object):
             )
 
         x = np.array(x_acc)
-        self.overfluctuations[ts_val] = x, y, yerr
+        self.overfluctuations[ts_val] = x, y, yerr, yerr_ts_jitter
 
         fit, err, extrapolated = self.sensitivity_fit(savepath, ts_val)
         return fit, err, extrapolated
 
     def sensitivity_fit(self, savepath, ts_val):
-        x, y, yerr = self.overfluctuations[ts_val]
+        x, y, yerr, yerr_ts_jitter = self.overfluctuations[ts_val]
         x_flux = k_to_flux(x)
 
         threshold = 0.9
@@ -612,7 +618,7 @@ class ResultsHandler(object):
 
         fig = plt.figure()
         ax1 = fig.add_subplot(111)
-        ax1.errorbar(x_flux, y, yerr=yerr, color="black", fmt=" ", marker="o")
+        ax1.errorbar(x_flux, y, yerr=yerr_ts_jitter, color="black", fmt=" ", marker="o")
         ax1.plot(k_to_flux(xrange), best_f(xrange), color="blue")
         ax1.fill_between(
             k_to_flux(xrange),

--- a/flarestack/data/icecube/northern_tracks/__init__.py
+++ b/flarestack/data/icecube/northern_tracks/__init__.py
@@ -263,6 +263,7 @@ class NTSeason(IceCubeSeason):
         ind = np.searchsorted(p_select, np.sort(rng.uniform(size=n_bkg)), side="right")
 
         sim_bkg = mc[ind]
+        sim_bkg["ra"] = np.random.uniform(0, 2 * np.pi, size=n_bkg)
 
         # Simulates random times
         time_pdf = self.get_time_pdf()

--- a/flarestack/data/icecube/northern_tracks/__init__.py
+++ b/flarestack/data/icecube/northern_tracks/__init__.py
@@ -177,6 +177,7 @@ class NTSeason(IceCubeSeason):
         )
 
         sim_bkg = mc[ind]
+        sim_bkg["ra"] = np.random.uniform(0, 2 * np.pi, size=n_bkg)
 
         time_pdf = self.get_time_pdf()
 


### PR DESCRIPTION
introduced two small updates:

- shuffle NTSeason background events in RA. This makes RA distribution more uniform and mitigate bias plot offset when using a single source and NT dataset.

- update errorbars on the sensitivity curve. Previous errorbars just used `1/sqrt(n_trials)` and completely ignored how TS distributions look like. The new method shifts TS values by `mean(TS)/sqrt(n_trials)` and estimate overfluctuation fraction at each edge as the error range. (The new method is not used for sensitivity fitting for now)

Below you can find the improvement of these updates :

- Before the RA shuffling (Nsrc=1, scale=100, DEC=53.5 deg)

<img width="530" height="295" alt="Screenshot 2026-03-19 at 15 53 14" src="https://github.com/user-attachments/assets/b5ecffdb-8faf-4495-b582-c245a72b7d96" />

- After the RA shuffling (Nsrc=1, scale=100, DEC=53.5 deg)

<img width="530" height="295" alt="Screenshot 2026-03-19 at 15 53 38" src="https://github.com/user-attachments/assets/f150ab89-8f8f-4857-8411-b57cfea4f217" />

- Before and after the errorbar estimate update

<img width="516" height="179" alt="Screenshot 2026-03-19 at 15 48 37" src="https://github.com/user-attachments/assets/b3300069-f4c4-4945-9cab-3703a4f6dbf0" />


